### PR TITLE
chore(top level): changes properties of ToplevelMeta to public.

### DIFF
--- a/src/zwlr_foreign_toplevel_management_v1/handler.rs
+++ b/src/zwlr_foreign_toplevel_management_v1/handler.rs
@@ -173,8 +173,8 @@ pub struct Toplevel {
 
 #[derive(Debug, Clone)]
 pub struct ToplevelMeta {
-    app_id: String,
-    title: String,
+    pub app_id: String,
+    pub title: String,
     state: Option<Vec<ToplevelWState>>,
 }
 


### PR DESCRIPTION
1. changes properties of ToplevelMeta to public so that it can be accessed outside.